### PR TITLE
Add expiration to Tracking Compass and handle expiry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
                         </goals>
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/me/jordan/simpleplayertracker/Commands/Compass.java
+++ b/src/main/java/me/jordan/simpleplayertracker/Commands/Compass.java
@@ -42,7 +42,7 @@ public class Compass implements CommandExecutor{
         ItemMeta meta = trackerCompass.getItemMeta();
 
         // Set display name and lore
-        meta.setDisplayName(Utils.color("&eTracking Compass"));
+        meta.setDisplayName(Utils.color("&ePermanent Tracking Compass"));
         List<String> lore = new ArrayList<>();
         lore.add(Utils.color("&7Track players in the same world"));
         lore.add(Utils.color("&bSHIFT-Right-click to select target"));

--- a/src/main/java/me/jordan/simpleplayertracker/Listeners/CraftTrackerEvent.java
+++ b/src/main/java/me/jordan/simpleplayertracker/Listeners/CraftTrackerEvent.java
@@ -1,0 +1,52 @@
+package me.jordan.simpleplayertracker.Listeners;
+
+import me.jordan.simpleplayertracker.Main;
+import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.CraftItemEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+
+public class CraftTrackerEvent implements Listener {
+
+    private final Main plugin;
+
+    public CraftTrackerEvent(Main plugin) {
+        this.plugin = plugin;
+        plugin.getServer().getPluginManager().registerEvents(this, plugin);
+    }
+
+    @EventHandler
+    public void onCraft(CraftItemEvent event) {
+        ItemStack result = event.getInventory().getResult();
+        if (result == null || result.getType() != org.bukkit.Material.COMPASS) return;
+        if (!result.hasItemMeta()) return;
+
+        ItemMeta meta = result.getItemMeta();
+        if (meta.getDisplayName() == null) return;
+        if (!meta.getDisplayName().contains("Tracking")) return;
+
+        // Schedule a 1-tick delayed task to update each crafted item individually
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            ItemStack[] contents = event.getView().getPlayer().getInventory().getContents();
+            NamespacedKey key = new NamespacedKey(plugin, "creation_time");
+
+            for (int i = 0; i < contents.length; i++) {
+                ItemStack item = contents[i];
+                if (item == null) continue;
+                if (item.getType() != org.bukkit.Material.COMPASS) continue;
+                if (!item.hasItemMeta()) continue;
+
+                ItemMeta itemMeta = item.getItemMeta();
+                if (itemMeta.getDisplayName() != null && itemMeta.getDisplayName().contains("Tracking")) {
+                    // Set a fresh timestamp for this individual item
+                    itemMeta.getPersistentDataContainer().set(key, PersistentDataType.LONG, System.currentTimeMillis());
+                    item.setItemMeta(itemMeta);
+                }
+            }
+        }, 1L); // 1 tick later
+    }
+}

--- a/src/main/java/me/jordan/simpleplayertracker/Listeners/InteractEvent.java
+++ b/src/main/java/me/jordan/simpleplayertracker/Listeners/InteractEvent.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 
 import me.jordan.simpleplayertracker.Main;
 import me.jordan.simpleplayertracker.UI.PlayersUI;
+import me.jordan.simpleplayertracker.Util.Utils;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -28,7 +29,16 @@ public class InteractEvent implements Listener {
     @EventHandler
     public void onClick(PlayerInteractEvent e) {
         Player p = e.getPlayer();
+
         if (e.getItem() == null || !e.getItem().hasItemMeta()) return;
+        //p.sendMessage("Main.isExpired(e.getItem()) : "+Main.isExpired(e.getItem()));
+        if (Main.isExpired(e.getItem())){ // if compass is expired
+            p.sendMessage(Utils.color("&cThis Tracking Compass has expired!"));
+            p.getInventory().remove(e.getItem()); // delete expired item
+            e.setCancelled(true);
+            return;
+        }
+
         if (p.getInventory().getItemInMainHand().getType() == Material.COMPASS && (e.getAction() == Action.RIGHT_CLICK_BLOCK || e.getAction() == Action.RIGHT_CLICK_AIR)) {
             if (p.isSneaking()) {
                 p.openInventory(PlayersUI.GUI(p));


### PR DESCRIPTION
Introduces a 45-minute expiration for crafted Tracking Compasses by storing a creation timestamp in item metadata. Adds a scheduled task to periodically remove expired compasses from player inventories and notifies players upon removal. Updates crafting and interaction logic to support and enforce expiration, and improves compass display name and lore to reflect permanence and expiry.