### PR TITLE
Set max stack size to 1 for tracker compass

### DIFF
--- a/src/main/java/me/jordan/simpleplayertracker/Main.java
+++ b/src/main/java/me/jordan/simpleplayertracker/Main.java
@@ -187,6 +187,7 @@ public class Main extends JavaPlugin{
         meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
 
         meta.setLore(lore);
+        meta.setMaxStackSize(1); // stack 1
         trackerCompass.setItemMeta(meta);
 
         // Create shaped recipe


### PR DESCRIPTION
Added a call to setMaxStackSize(1) on the tracker compass item meta to ensure the item cannot be stacked. This helps enforce unique handling of the tracker compass.